### PR TITLE
Change serialization to nested block syntax by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This document provides instructions for AI agents working on the GSL-Lang projec
 ## Quick Commands
 
 ```bash
-make test                       # Run all tests with coverage
+make test                       # Run all tests with coverage (query fixtures run silently; use `go test -v -run TestFixtures ./query` to watch them)
 make test-integration           # Run integration tests (skip if tools missing)
 make test-integration-strict    # Run integration tests (fail if tools missing)
 make lint                       # Run linting

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -10,11 +10,7 @@ statement    ::= node_decl
                | scoped_edge_decl
                | set_decl
 
-node_decl    ::= "node" IDENT node_suffix? membership*
-
-node_suffix  ::= attribute_list
-               | ":" STRING
-               | block
+node_decl    ::= "node" IDENT (attribute_list | ":" STRING)? block? membership*
 
 block        ::= "{" statement* "}"
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -283,7 +283,8 @@ Block syntax:
 
 * MUST be treated as syntactic sugar.
 * Each node declared inside the block MUST implicitly receive `parent=<enclosing node>`.
-* Block structure MUST NOT be preserved in canonical form.
+* Block structure MUST be preserved as the canonical form.
+* Children inside a block MUST NOT include an explicit `parent` attribute (it is implicit).
 
 If a node inside a block explicitly declares a conflicting parent:
 
@@ -608,15 +609,20 @@ parse(serialize(parse(input))) == parse(input)
 Canonicalisation MUST:
 
 1. Expand grouped edges.
-2. Convert block syntax to explicit `parent` attributes.
-3. Preserve duplicate edges.
-4. Preserve empty attributes.
-5. Materialise implicitly created sets.
-6. Merge multiple declarations.
+2. Use nested block syntax for parent-child relationships (derived from `parent` attributes).
+3. Omit the explicit `parent` attribute within blocks (it is implicit from the nesting).
+4. Preserve duplicate edges.
+5. Preserve empty attributes.
+6. Materialise implicitly created sets.
+7. Merge multiple declarations.
 
 Ordering:
 
-* Ordering of nodes and sets in serialisation MAY be implementation-defined.
+* Ordering of sets in serialisation MUST be sorted by ID.
+* Ordering of nodes MUST be derived from their first appearance in edge declarations, with unreferenced nodes sorted by ID.
+* Ordering of edges MUST preserve declaration order.
+* Child nodes within a block MUST follow the same ordering rules.
+* Child edges within a scoped block MUST preserve declaration order.
 * Canonical form MUST parse into an identical internal representation.
 
 ---

--- a/examples/04-serialization/flat_edges.gsl
+++ b/examples/04-serialization/flat_edges.gsl
@@ -1,0 +1,5 @@
+# Flat style: child edges have explicit parent attribute
+# Demonstrates conversion to nested scoped blocks
+E1: A -> B
+B -> C [parent=E1]
+C -> D [parent=E1]

--- a/examples/04-serialization/flat_edges_nested.gsl
+++ b/examples/04-serialization/flat_edges_nested.gsl
@@ -1,0 +1,9 @@
+node A
+node B
+node C
+node D
+
+E1: A->B {
+    B->C
+    C->D
+}

--- a/examples/04-serialization/flat_nodes.gsl
+++ b/examples/04-serialization/flat_nodes.gsl
@@ -1,0 +1,5 @@
+# Flat style: child nodes have explicit parent attribute
+# Demonstrates conversion to nested block syntax
+node C
+node B [parent=C]
+node A [parent=B]

--- a/examples/04-serialization/flat_nodes_nested.gsl
+++ b/examples/04-serialization/flat_nodes_nested.gsl
@@ -1,0 +1,5 @@
+node C {
+    node B {
+        node A
+    }
+}

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"testing"
 
 	gsl "github.com/dnnrly/gsl-lang"
 )
@@ -203,6 +204,42 @@ A->B`
 	// node B [text="End"]
 	//
 	// A->B
+}
+
+func TestFlatNodeParentToNested(t *testing.T) {
+	input, err := os.ReadFile("04-serialization/flat_nodes.gsl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph, _ := gsl.Parse(bytes.NewReader(input))
+	actual := gsl.Serialize(graph)
+
+	expected, err := os.ReadFile("04-serialization/flat_nodes_nested.gsl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual != strings.TrimRight(string(expected), "\n") {
+		t.Errorf("got:\n%s\n\nwant:\n%s", actual, string(expected))
+	}
+}
+
+func TestFlatEdgeParentToNested(t *testing.T) {
+	input, err := os.ReadFile("04-serialization/flat_edges.gsl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph, _ := gsl.Parse(bytes.NewReader(input))
+	actual := gsl.Serialize(graph)
+
+	expected, err := os.ReadFile("04-serialization/flat_edges_nested.gsl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual != strings.TrimRight(string(expected), "\n") {
+		t.Errorf("got:\n%s\n\nwant:\n%s", actual, string(expected))
+	}
 }
 
 // Example_graphStatistics demonstrates basic graph statistics.

--- a/gsl_test.go
+++ b/gsl_test.go
@@ -162,7 +162,7 @@ func TestRoundTripLabeledEdge(t *testing.T) {
 }
 
 func TestRoundTripScopedEdge(t *testing.T) {
-	// Scoped edges should flatten to parent in canonical form
+	// Scoped edges should use nested block syntax in canonical form
 	input := "E1: A -> B { B -> C }"
 	g1, parseErr := Parse(strings.NewReader(input))
 	if parseErr != nil && parseErr.HasError() {
@@ -179,10 +179,13 @@ func TestRoundTripScopedEdge(t *testing.T) {
 		t.Errorf("expected child edge to have parent E1, got %q", edges[1].Parent)
 	}
 
-	// Serialize and verify canonical form has parent
+	// Serialize and verify canonical form uses nested block
 	canonical := Serialize(g1)
-	if !strings.Contains(canonical, "parent=E1") {
-		t.Errorf("canonical form should contain parent=E1, got: %s", canonical)
+	if !strings.Contains(canonical, "{") {
+		t.Errorf("canonical form should contain nested block, got: %s", canonical)
+	}
+	if strings.Contains(canonical, "parent=E1") {
+		t.Errorf("canonical form should not contain explicit parent=E1 inside block, got: %s", canonical)
 	}
 
 	// Re-parse and verify

--- a/parser.go
+++ b/parser.go
@@ -116,17 +116,22 @@ func (p *parser) parseNodeDecl() *nodeDecl {
 	}
 	nd.name = p.advance().Literal
 
-	// Parse optional suffix
-	switch p.peek().Type {
-	case TOKEN_LBRACKET:
+	// Parse attributes (optional, can be followed by block)
+	if p.peek().Type == TOKEN_LBRACKET {
 		nd.attrs = p.parseAttributeList(true)
-	case TOKEN_COLON:
+	}
+
+	// Parse text shorthand (mutually exclusive with attributes)
+	if len(nd.attrs) == 0 && p.peek().Type == TOKEN_COLON {
 		p.advance() // consume ':'
 		strTok := p.expect(TOKEN_STRING)
 		if strTok.Type == TOKEN_STRING {
 			nd.textValue = &strTok.Literal
 		}
-	case TOKEN_LBRACE:
+	}
+
+	// Parse block (optional, can follow attributes)
+	if p.peek().Type == TOKEN_LBRACE {
 		nd.block = p.parseBlock(nd.name)
 	}
 

--- a/serialize.go
+++ b/serialize.go
@@ -89,39 +89,60 @@ func serializeNodes(nodes map[string]*Node, edges []*Edge) string {
 // Parent-child relationships are built from the Parent field at serialization
 // time (consistent with how node nesting works), not from the pre-populated
 // Children field which may not be set in all code paths.
+// Edges in parent cycles are treated as roots with explicit parent attribute.
 func serializeEdges(edges []*Edge) string {
 	// Build parent label → children map from Parent field
-	childMap := make(map[string][]*Edge)
-	for _, e := range edges {
-		if e.Parent != "" {
-			childMap[e.Parent] = append(childMap[e.Parent], e)
-		}
-	}
-
-	// Identify root edges (no Parent or parent label not present)
-	labelIndex := make(map[string]bool)
+	// Index edges by label for cycle detection
+	labelIndex := make(map[string]*Edge)
 	for _, e := range edges {
 		if e.Label != "" {
-			labelIndex[e.Label] = true
+			labelIndex[e.Label] = e
 		}
 	}
 
+	// Build parent label → children map, excluding cyclic edges
+	// (cyclic edges are output at root level with explicit parent attribute)
+	childMap := make(map[string][]*Edge)
 	childSet := make(map[*Edge]bool)
 	for _, e := range edges {
 		if e.Parent != "" {
-			if labelIndex[e.Parent] {
+			parentExists := labelIndex[e.Parent] != nil
+			cyclic := parentExists && isEdgeCyclic(e, labelIndex)
+			if parentExists && !cyclic {
+				childMap[e.Parent] = append(childMap[e.Parent], e)
 				childSet[e] = true
 			}
 		}
 	}
 
 	var lines []string
+	visiting := make(map[string]bool)
 	for _, e := range edges {
 		if !childSet[e] {
-			lines = append(lines, serializeEdgeNested(e, childMap))
+			lines = append(lines, serializeEdgeNested(e, childMap, visiting))
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// isEdgeCyclic walks the edge parent chain to detect cycles.
+func isEdgeCyclic(e *Edge, labelIndex map[string]*Edge) bool {
+	visited := make(map[string]bool)
+	current := e
+	for current != nil && current.Parent != "" {
+		if current.Label != "" {
+			if visited[current.Label] {
+				return true
+			}
+			visited[current.Label] = true
+		}
+		parent, ok := labelIndex[current.Parent]
+		if !ok {
+			return false
+		}
+		current = parent
+	}
+	return false
 }
 
 // buildNodePositions returns node ID to first edge index referencing it.
@@ -213,9 +234,6 @@ func serializeNodeNested(n *Node, children []*Node, childMap map[string][]*Node,
 		b.WriteString(serializeAttrs(attrs))
 	}
 
-	// Set memberships
-	b.WriteString(serializeSetMemberships(n.Sets))
-
 	// Block children (if any and no cycle)
 	if len(children) > 0 && !visiting[n.ID] {
 		visiting[n.ID] = true
@@ -230,10 +248,13 @@ func serializeNodeNested(n *Node, children []*Node, childMap map[string][]*Node,
 		visiting[n.ID] = false
 	}
 
+	// Memberships must come after block (parser expects this order)
+	b.WriteString(serializeSetMemberships(n.Sets))
+
 	return b.String()
 }
 
-func serializeEdgeNested(e *Edge, childMap map[string][]*Edge) string {
+func serializeEdgeNested(e *Edge, childMap map[string][]*Edge, visiting map[string]bool) string {
 	var b strings.Builder
 
 	if e.Label != "" {
@@ -251,14 +272,16 @@ func serializeEdgeNested(e *Edge, childMap map[string][]*Edge) string {
 	}
 	b.WriteString(serializeSetMemberships(e.Sets))
 
-	if children, ok := childMap[e.Label]; ok && len(children) > 0 {
+	if children, ok := childMap[e.Label]; ok && len(children) > 0 && !visiting[e.Label] {
+		visiting[e.Label] = true
 		b.WriteString(" {\n")
 		for _, child := range children {
-			childStr := serializeEdgeNested(child, childMap)
+			childStr := serializeEdgeNested(child, childMap, visiting)
 			b.WriteString(indentBlock(childStr, "    "))
 			b.WriteString("\n")
 		}
 		b.WriteString("}")
+		visiting[e.Label] = false
 	}
 
 	return b.String()

--- a/serialize.go
+++ b/serialize.go
@@ -8,8 +8,10 @@ import (
 )
 
 // Serialize converts a Graph to canonical GSL text.
-// Output is deterministic: sets first (sorted by ID), nodes second (sorted by ID),
-// edges last (in slice order). Attribute keys are sorted alphabetically.
+// Output uses nested block syntax for parent-child relationships.
+// Deterministic: sets first (sorted by ID), root nodes next (ordered by
+// first appearance in edge list, then by ID), root edges last (in slice order).
+// Children are nested under their parent using block syntax.
 func Serialize(g *Graph) string {
 	if g == nil {
 		return ""
@@ -33,33 +35,146 @@ func Serialize(g *Graph) string {
 		sections = append(sections, strings.Join(lines, "\n"))
 	}
 
-	// Nodes, sorted by ID
+	// Nodes, with nesting
 	nodes := g.GetNodes()
 	if len(nodes) > 0 {
-		nodeIDs := make([]string, 0, len(nodes))
-		for id := range nodes {
-			nodeIDs = append(nodeIDs, id)
-		}
-		sort.Strings(nodeIDs)
-
-		var lines []string
-		for _, id := range nodeIDs {
-			lines = append(lines, serializeNode(nodes[id]))
-		}
-		sections = append(sections, strings.Join(lines, "\n"))
+		sections = append(sections, serializeNodes(nodes, g.GetEdges()))
 	}
 
-	// Edges, in slice order
+	// Edges, with nesting built from Parent field at serialization time
 	edges := g.GetEdges()
 	if len(edges) > 0 {
-		var lines []string
-		for _, e := range edges {
-			lines = append(lines, serializeEdge(e))
-		}
-		sections = append(sections, strings.Join(lines, "\n"))
+		sections = append(sections, serializeEdges(edges))
 	}
 
 	return strings.Join(sections, "\n\n")
+}
+
+// serializeNodes builds the parent-child tree and serializes with recursive nesting.
+func serializeNodes(nodes map[string]*Node, edges []*Edge) string {
+	positions := buildNodePositions(edges)
+
+	// Build parent->children map, detecting cycles
+	children := make(map[string][]*Node)
+	for _, n := range nodes {
+		if n.Parent != nil {
+			if _, ok := nodes[*n.Parent]; ok && !isCyclic(n, nodes) {
+				children[*n.Parent] = append(children[*n.Parent], n)
+			}
+		}
+	}
+
+	// Sort children within each parent
+	for id := range children {
+		sortNodesByPosition(children[id], positions)
+	}
+
+	// Determine roots: no parent, parent doesn't exist, or in a cycle
+	roots := []*Node{}
+	for _, n := range nodes {
+		if n.Parent == nil || nodes[*n.Parent] == nil || isCyclic(n, nodes) {
+			roots = append(roots, n)
+		}
+	}
+	sortNodesByPosition(roots, positions)
+
+	var lines []string
+	for _, n := range roots {
+		lines = append(lines, serializeNodeNested(n, children[n.ID], children, make(map[string]bool), false))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// serializeEdges identifies root edges and serializes children inside blocks.
+// Parent-child relationships are built from the Parent field at serialization
+// time (consistent with how node nesting works), not from the pre-populated
+// Children field which may not be set in all code paths.
+func serializeEdges(edges []*Edge) string {
+	// Build parent label → children map from Parent field
+	childMap := make(map[string][]*Edge)
+	for _, e := range edges {
+		if e.Parent != "" {
+			childMap[e.Parent] = append(childMap[e.Parent], e)
+		}
+	}
+
+	// Identify root edges (no Parent or parent label not present)
+	labelIndex := make(map[string]bool)
+	for _, e := range edges {
+		if e.Label != "" {
+			labelIndex[e.Label] = true
+		}
+	}
+
+	childSet := make(map[*Edge]bool)
+	for _, e := range edges {
+		if e.Parent != "" {
+			if labelIndex[e.Parent] {
+				childSet[e] = true
+			}
+		}
+	}
+
+	var lines []string
+	for _, e := range edges {
+		if !childSet[e] {
+			lines = append(lines, serializeEdgeNested(e, childMap))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// buildNodePositions returns node ID to first edge index referencing it.
+func buildNodePositions(edges []*Edge) map[string]int {
+	positions := make(map[string]int)
+	for i, e := range edges {
+		if _, ok := positions[e.From]; !ok {
+			positions[e.From] = i
+		}
+		if _, ok := positions[e.To]; !ok {
+			positions[e.To] = i
+		}
+	}
+	return positions
+}
+
+// sortNodesByPosition sorts nodes by first edge appearance, then ID.
+func sortNodesByPosition(nodes []*Node, positions map[string]int) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		pi, hasI := positions[nodes[i].ID]
+		pj, hasJ := positions[nodes[j].ID]
+		if hasI && hasJ {
+			if pi != pj {
+				return pi < pj
+			}
+			return nodes[i].ID < nodes[j].ID
+		}
+		if hasI {
+			return true
+		}
+		if hasJ {
+			return false
+		}
+		return nodes[i].ID < nodes[j].ID
+	})
+}
+
+// isCyclic walks the parent chain to detect cycles.
+func isCyclic(n *Node, allNodes map[string]*Node) bool {
+	visited := make(map[string]bool)
+	current := n
+	for current != nil && current.Parent != nil {
+		if visited[current.ID] {
+			return true
+		}
+		visited[current.ID] = true
+		parent, ok := allNodes[*current.Parent]
+		if !ok {
+			return false
+		}
+		current = parent
+	}
+	return false
 }
 
 func serializeSet(s *Set) string {
@@ -73,22 +188,54 @@ func serializeSet(s *Set) string {
 	return b.String()
 }
 
-func serializeNode(n *Node) string {
+// serializeNodeNested serializes a node with optional block children.
+// stripParent controls whether the "parent" attribute is omitted (true when
+// inside a block where parent is implicit).
+func serializeNodeNested(n *Node, children []*Node, childMap map[string][]*Node, visiting map[string]bool, stripParent bool) string {
 	var b strings.Builder
 	b.WriteString("node ")
 	b.WriteString(n.ID)
-	if len(n.Attributes) > 0 {
-		b.WriteString(" ")
-		b.WriteString(serializeAttrs(n.Attributes))
+
+	// Build attrs, omitting parent when inside a block
+	var attrs map[string]interface{}
+	if stripParent {
+		attrs = make(map[string]interface{})
+		for k, v := range n.Attributes {
+			if k != "parent" {
+				attrs[k] = v
+			}
+		}
+	} else {
+		attrs = n.Attributes
 	}
+	if len(attrs) > 0 {
+		b.WriteString(" ")
+		b.WriteString(serializeAttrs(attrs))
+	}
+
+	// Set memberships
 	b.WriteString(serializeSetMemberships(n.Sets))
+
+	// Block children (if any and no cycle)
+	if len(children) > 0 && !visiting[n.ID] {
+		visiting[n.ID] = true
+		b.WriteString(" {\n")
+		for _, child := range children {
+			grandchildren := childMap[child.ID]
+			childStr := serializeNodeNested(child, grandchildren, childMap, visiting, true)
+			b.WriteString(indentBlock(childStr, "    "))
+			b.WriteString("\n")
+		}
+		b.WriteString("}")
+		visiting[n.ID] = false
+	}
+
 	return b.String()
 }
 
-func serializeEdge(e *Edge) string {
+func serializeEdgeNested(e *Edge, childMap map[string][]*Edge) string {
 	var b strings.Builder
 
-	// Output edge label if present
 	if e.Label != "" {
 		b.WriteString(e.Label)
 		b.WriteString(": ")
@@ -98,20 +245,22 @@ func serializeEdge(e *Edge) string {
 	b.WriteString("->")
 	b.WriteString(e.To)
 
-	// Build attributes including parent
-	attrs := make(map[string]interface{})
-	for k, v := range e.Attributes {
-		attrs[k] = v
-	}
-	if e.Parent != "" {
-		attrs["parent"] = e.Parent
-	}
-
-	if len(attrs) > 0 {
+	if len(e.Attributes) > 0 {
 		b.WriteString(" ")
-		b.WriteString(serializeAttrs(attrs))
+		b.WriteString(serializeAttrs(e.Attributes))
 	}
 	b.WriteString(serializeSetMemberships(e.Sets))
+
+	if children, ok := childMap[e.Label]; ok && len(children) > 0 {
+		b.WriteString(" {\n")
+		for _, child := range children {
+			childStr := serializeEdgeNested(child, childMap)
+			b.WriteString(indentBlock(childStr, "    "))
+			b.WriteString("\n")
+		}
+		b.WriteString("}")
+	}
+
 	return b.String()
 }
 
@@ -152,7 +301,6 @@ func serializeAttr(key string, value interface{}) string {
 	}
 	switch v := value.(type) {
 	case string:
-		// Special case: parent outputs as identifier (no quotes)
 		if key == "parent" {
 			return key + "=" + v
 		}
@@ -195,4 +343,12 @@ func formatNumber(f float64) string {
 		return strconv.FormatFloat(f, 'f', 0, 64)
 	}
 	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+func indentBlock(s string, indent string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = indent + line
+	}
+	return strings.Join(lines, "\n")
 }

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -141,7 +141,64 @@ func TestSerializeNodeWithParent(t *testing.T) {
 		nil,
 	)
 	got := Serialize(g)
-	expected := "node A [parent=B]\nnode B"
+	expected := "node B {\n    node A\n}"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSerializeNestedNodeHierarchy(t *testing.T) {
+	parentB := "A"
+	parentC := "B"
+	g := testGraph(
+		map[string]*Node{
+			"A": {
+				ID:         "A",
+				Attributes: map[string]interface{}{},
+				Sets:       map[string]struct{}{},
+			},
+			"B": {
+				ID:         "B",
+				Attributes: map[string]interface{}{"color": "red"},
+				Sets:       map[string]struct{}{},
+				Parent:     &parentB,
+			},
+			"C": {
+				ID:         "C",
+				Attributes: map[string]interface{}{"flag": nil},
+				Sets:       map[string]struct{}{"group": {}},
+				Parent:     &parentC,
+			},
+		},
+		map[string]*Set{
+			"group": {ID: "group", Attributes: map[string]interface{}{}},
+		},
+		nil,
+	)
+	got := Serialize(g)
+	expected := "set group\n\nnode A {\n    node B [color=\"red\"] {\n        node C [flag] @group\n    }\n}"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSerializeNodeWithParentMissing(t *testing.T) {
+	parent := "Missing"
+	g := testGraph(
+		map[string]*Node{
+			"A": {
+				ID:         "A",
+				Attributes: map[string]interface{}{"parent": NodeRef("Missing")},
+				Sets:       map[string]struct{}{},
+				Parent:     &parent,
+			},
+		},
+		map[string]*Set{},
+		nil,
+	)
+	got := Serialize(g)
+	// Parent doesn't exist in graph, so A outputs at root level with explicit parent
+	expected := "node A [parent=Missing]"
 	if got != expected {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
@@ -203,6 +260,85 @@ func TestSerializeEdgeWithMembership(t *testing.T) {
 	}
 }
 
+func TestSerializeEdgeWithNestedScope(t *testing.T) {
+	childEdge := &Edge{
+		From:       "B",
+		To:         "C",
+		Parent:     "E1",
+		Attributes: map[string]interface{}{},
+		Sets:       map[string]struct{}{},
+	}
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"B": {ID: "B", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"C": {ID: "C", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{
+				From:       "A",
+				To:         "B",
+				Label:      "E1",
+				Attributes: map[string]interface{}{},
+				Sets:       map[string]struct{}{},
+				Children:   []*Edge{childEdge},
+			},
+			childEdge,
+		},
+	)
+	got := Serialize(g)
+	expected := "node A\nnode B\nnode C\n\nE1: A->B {\n    B->C\n}"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSerializeEdgeWithDeeplyNestedScope(t *testing.T) {
+	edgeCD := &Edge{
+		From:       "C",
+		To:         "D",
+		Parent:     "E2",
+		Attributes: map[string]interface{}{},
+		Sets:       map[string]struct{}{},
+	}
+	edgeE2 := &Edge{
+		From:       "B",
+		To:         "C",
+		Label:      "E2",
+		Parent:     "E1",
+		Attributes: map[string]interface{}{},
+		Sets:       map[string]struct{}{},
+		Children:   []*Edge{edgeCD},
+	}
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"B": {ID: "B", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"C": {ID: "C", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"D": {ID: "D", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{
+				From:       "A",
+				To:         "B",
+				Label:      "E1",
+				Attributes: map[string]interface{}{},
+				Sets:       map[string]struct{}{},
+				Children:   []*Edge{edgeE2},
+			},
+			edgeE2,
+			edgeCD,
+		},
+	)
+	got := Serialize(g)
+	expected := "node A\nnode B\nnode C\nnode D\n\nE1: A->B {\n    E2: B->C {\n        C->D\n    }\n}"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
 func TestSerializeSet(t *testing.T) {
 	g := testGraph(
 		map[string]*Node{},
@@ -249,6 +385,8 @@ func TestSerializeOrdering(t *testing.T) {
 		},
 	)
 	got := Serialize(g)
+	// Nodes ordered by first edge appearance: Z (edge 0), A (edge 0).
+	// Both at edge 0, tiebreak by ID: A then Z.
 	expected := "set alpha\nset beta\n\nnode A\nnode Z\n\nZ->A\nA->Z"
 	if got != expected {
 		t.Errorf("expected %q, got %q", expected, got)

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -339,6 +339,50 @@ func TestSerializeEdgeWithDeeplyNestedScope(t *testing.T) {
 	}
 }
 
+func TestSerializeEdgeCyclicDependency(t *testing.T) {
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"B": {ID: "B", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"C": {ID: "C", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{
+				From:       "A",
+				To:         "B",
+				Label:      "E1",
+				Parent:     "E3",
+				Attributes: map[string]interface{}{"parent": "E3"},
+				Sets:       map[string]struct{}{},
+			},
+			{
+				From:       "B",
+				To:         "C",
+				Label:      "E2",
+				Parent:     "E1",
+				Attributes: map[string]interface{}{"parent": "E1"},
+				Sets:       map[string]struct{}{},
+			},
+			{
+				From:       "C",
+				To:         "A",
+				Label:      "E3",
+				Parent:     "E2",
+				Attributes: map[string]interface{}{"parent": "E2"},
+				Sets:       map[string]struct{}{},
+			},
+		},
+	)
+	got := Serialize(g)
+	// All three edges are in a cycle, so none is nested.
+	// Each appears at root level with explicit parent attribute.
+	expected := "node A\nnode B\nnode C\n\nE1: A->B [parent=E3]\nE2: B->C [parent=E1]\nE3: C->A [parent=E2]"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
 func TestSerializeSet(t *testing.T) {
 	g := testGraph(
 		map[string]*Node{},


### PR DESCRIPTION
## Summary
`Serialize()` now outputs nested `{ ... }` blocks for parent-child relationships instead of flat explicit `parent` attributes.

Before (flat):
```
node A parent=C
node B parent=C
node C
E1: A->B
B->C parent=E1
```

After (nested):
```
node C {
    node A
    node B
}
E1: A->B {
    B->C
}
```

Key details:
- Parent-child trees built from the `Parent` field at serialization time (not from pre-populated `Children` slices)
- Children inside blocks omit explicit `parent` attribute (implicit from nesting)
- Cycle detection prevents infinite recursion
- Round-trip guarantee preserved: `parse(serialize(parse(x))) == parse(x)`