### PR TITLE
Bug fixes from fuzzing failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@ Before submitting changes:
 - [ ] Lint passes: `make lint`
 - [ ] Markdown validates: `go test -v -run TestMarkdownCodeBlocks`
 - [ ] Round-trip tests added (if touching parser/serializer)
+- [ ] Example fixture (`.gsl` file in `examples/`) added for serialization round-trip fixes
 - [ ] Integration tests added (if modifying CLI tools or converters)
 - [ ] LSP tests pass: `go test ./lsp/...`
 - [ ] LSP file structure updated in this file if reorganizing lsp/

--- a/SPEC.md
+++ b/SPEC.md
@@ -386,7 +386,7 @@ E1: A -> B
 
 Labels:
 
-* MUST uniquely identify an edge within scope
+* MUST be globally unique
 * MAY be used as dependency targets
 
 ---
@@ -649,6 +649,9 @@ The following conditions MUST produce a syntax error:
 * NodeRef values in set attributes.
 * Use of reserved keywords as identifiers.
 * Explicit `parent` inside scoped edges.
+* Duplicate edge labels (labels are globally unique).
+
+---
 
 ---
 
@@ -683,6 +686,14 @@ node node
 ```
 
 Reserved keyword `node` used as identifier (invalid).
+
+```invalid-gsl
+X: A -> B {
+    X: C -> D
+}
+```
+
+Duplicate edge label `X` in nested scope (labels are globally unique).
 
 ---
 

--- a/build.go
+++ b/build.go
@@ -136,12 +136,12 @@ func (b *builder) processEdgeDeclWithScope(ed *edgeDecl, insideScope bool) {
 		return
 	}
 
-	// Check for label uniqueness within current scope
+	// Check for label uniqueness across all scopes (global uniqueness)
 	var edgeLabel string
 	if ed.label != nil {
 		edgeLabel = *ed.label
-		if b.edgeScope != nil {
-			if _, exists := b.edgeScope.labels[edgeLabel]; exists {
+		for scope := b.edgeScope; scope != nil; scope = scope.outer {
+			if _, exists := scope.labels[edgeLabel]; exists {
 				b.errors = append(b.errors, fmt.Errorf("%d:%d: duplicate edge label %q", ed.line, ed.col, edgeLabel))
 				return
 			}
@@ -259,12 +259,15 @@ func (b *builder) processScopedBlock(stmts []statement, parentLabel string) {
 
 // populateChildren populates Children pointers on each edge from Parent references.
 // For each edge with Parent set, the parent edge (matched by label) gets this edge
-// appended to its Children slice.
+// appended to its Children slice. Uses first-write-wins for label resolution
+// (matching the serializer) since labels are globally unique.
 func (b *builder) populateChildren() {
 	labelIndex := make(map[string]*Edge)
 	for _, edge := range b.graph.edges {
 		if edge.Label != "" {
-			labelIndex[edge.Label] = edge
+			if _, exists := labelIndex[edge.Label]; !exists {
+				labelIndex[edge.Label] = edge
+			}
 		}
 	}
 	for _, edge := range b.graph.edges {

--- a/build_test.go
+++ b/build_test.go
@@ -1070,8 +1070,7 @@ func TestBuildDuplicateLabelError(t *testing.T) {
 
 func TestBuildNestedScopeLabelShadowing(t *testing.T) {
 	// E1: A -> B { C -> D E1: E -> F }
-	// Nested scopes allow label shadowing - inner E1 shadows outer E1
-	// This should succeed per the spec
+	// Labels are globally unique - shadowing is not allowed
 	label := "E1"
 	innerLabel := "E1"
 	child2 := &edgeDecl{
@@ -1096,37 +1095,12 @@ func TestBuildNestedScopeLabelShadowing(t *testing.T) {
 			},
 		},
 	}
-	g, _, err := buildGraph(prog)
-	if err != nil {
-		t.Fatalf("unexpected error for nested scope label shadowing: %v", err)
+	_, _, err := buildGraph(prog)
+	if err == nil {
+		t.Fatal("expected error for duplicate edge label in nested scope")
 	}
-	edges := g.GetEdges()
-	if len(edges) != 3 {
-		t.Fatalf("expected 3 edges, got %d", len(edges))
-	}
-	// Verify both labeled edges exist
-	outerFound := false
-	innerFound := false
-	for _, e := range edges {
-		if e.Label == "E1" {
-			if e.From == "A" && e.To == "B" {
-				outerFound = true
-				if e.Parent != "" {
-					t.Errorf("outer edge should have no dependency")
-				}
-			} else if e.From == "E" && e.To == "F" {
-				innerFound = true
-				if e.Parent != "E1" {
-					t.Errorf("inner edge should depend on outer E1")
-				}
-			}
-		}
-	}
-	if !outerFound {
-		t.Error("outer E1 edge not found")
-	}
-	if !innerFound {
-		t.Error("inner E1 edge not found")
+	if !strings.Contains(err.Error(), "duplicate edge label") {
+		t.Errorf("expected 'duplicate edge label' error, got: %v", err)
 	}
 }
 

--- a/examples/04-serialization/grouped_edges.gsl
+++ b/examples/04-serialization/grouped_edges.gsl
@@ -1,0 +1,3 @@
+# Labeled grouped edges with round-trip correctness
+# Serialization must reconstruct grouped form to avoid duplicate-label error
+A: A->A,A

--- a/examples/README.md
+++ b/examples/README.md
@@ -144,7 +144,6 @@ A labeled grouped edge with duplicate nodes that must be serialized as a grouped
 - Avoiding duplicate edge label error in re-parsed output
 
 ---
-
 ## Example Tests
 
 `example_test.go` contains runnable documentation examples that demonstrate common patterns:

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,6 +130,21 @@ Demonstrates parent override inside block warnings.
 
 ---
 
+## 04-serialization — Serialization Round-Trip
+
+Graphs that verify canonical serialization produces parseable output.
+
+### `grouped_edges.gsl`
+
+A labeled grouped edge with duplicate nodes that must be serialized as a grouped declaration to preserve round-trip correctness.
+
+**Demonstrates:**
+- Labeled grouped edges
+- Serialization round-trip with duplicate edges sharing a label
+- Avoiding duplicate edge label error in re-parsed output
+
+---
+
 ## Example Tests
 
 `example_test.go` contains runnable documentation examples that demonstrate common patterns:
@@ -185,6 +200,7 @@ go test ./examples -v
 | Implicit sets warning | `03-edge-cases/implicit_sets.gsl` |
 | Name collision warning | `03-edge-cases/name_collision.gsl` |
 | Parent override warning | `03-edge-cases/parent_override.gsl` |
+| Labeled grouped edges | `04-serialization/grouped_edges.gsl` |
 
 ## Graph Sizes
 
@@ -200,6 +216,7 @@ go test ./examples -v
 | `03-edge-cases/implicit_sets.gsl` | 4 | 1 | 2 |
 | `03-edge-cases/name_collision.gsl` | 3 | 2 | 1 |
 | `03-edge-cases/parent_override.gsl` | 4 | 0 | 0 |
+| `04-serialization/grouped_edges.gsl` | 1 | 2 | 0 |
 
 ## More Information
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -140,6 +140,7 @@ func FuzzRoundTrip(f *testing.F) {
 	f.Add("A -> B { node C C -> D }")
 	f.Add("A -> B { set flow B -> C }")
 	f.Add("node A [x=1] @s1 @s2")
+	f.Add("A:A->A,A")
 
 	for _, input := range loadGSLFiles("examples", "query/testdata") {
 		f.Add(input)

--- a/gsl_test.go
+++ b/gsl_test.go
@@ -257,6 +257,19 @@ func TestParseWithErrors(t *testing.T) {
 	}
 }
 
+func TestParseDuplicateLabelAcrossScopes(t *testing.T) {
+	// Reusing the same edge label in a nested scope is an error
+	// (labels are globally unique)
+	input := "X: A -> B {\n    X: C -> D\n}"
+	_, parseErr := Parse(strings.NewReader(input))
+	if parseErr == nil || !parseErr.HasError() {
+		t.Fatal("expected error for duplicate label in nested scope")
+	}
+	if !strings.Contains(parseErr.Error(), "duplicate edge label") {
+		t.Errorf("expected 'duplicate edge label' error, got: %v", parseErr)
+	}
+}
+
 // assertRoundTrip parses input, serializes, re-parses, and checks equality.
 func assertRoundTrip(t *testing.T, input string) {
 	t.Helper()

--- a/gsl_test.go
+++ b/gsl_test.go
@@ -161,6 +161,25 @@ func TestRoundTripLabeledEdge(t *testing.T) {
 	assertRoundTrip(t, input)
 }
 
+func TestRoundTripLabeledGroupedEdgeRight(t *testing.T) {
+	// Labeled grouped edge (right-grouped) should round-trip.
+	// This was a fuzzing failure: the serializer must reconstruct grouped form.
+	input := "A:A->A,A"
+	assertRoundTrip(t, input)
+}
+
+func TestRoundTripLabeledGroupedEdgeLeft(t *testing.T) {
+	// Labeled grouped edge (left-grouped) should round-trip.
+	input := "A: A,A->A"
+	assertRoundTrip(t, input)
+}
+
+func TestRoundTripLabeledGroupedEdgeDistinct(t *testing.T) {
+	// Labeled grouped edge with distinct nodes should round-trip.
+	input := "X: A,B->Z"
+	assertRoundTrip(t, input)
+}
+
 func TestRoundTripScopedEdge(t *testing.T) {
 	// Scoped edges should use nested block syntax in canonical form
 	input := "E1: A -> B { B -> C }"

--- a/query/predicates.go
+++ b/query/predicates.go
@@ -268,20 +268,27 @@ func (p *DepthPredicate) computeDepth(edge *gsl.Edge) int {
 		return 0
 	}
 	if globalLabelIndex != nil {
-		return p.walkDepth(edge, 0)
+		return p.walkDepth(edge, 0, make(map[string]bool))
 	}
 	return 1
 }
 
-func (p *DepthPredicate) walkDepth(edge *gsl.Edge, depth int) int {
+func (p *DepthPredicate) walkDepth(edge *gsl.Edge, depth int, visited map[string]bool) int {
 	if edge.Parent == "" {
 		return depth
+	}
+	// Detect cycles in the parent chain to prevent infinite recursion
+	if edge.Label != "" {
+		if visited[edge.Label] {
+			return depth
+		}
+		visited[edge.Label] = true
 	}
 	parent, ok := globalLabelIndex[edge.Parent]
 	if !ok || parent == nil {
 		return depth + 1 // can't walk further, estimate
 	}
-	return p.walkDepth(parent, depth+1)
+	return p.walkDepth(parent, depth+1, visited)
 }
 
 func (p *DepthPredicate) TargetType() string { return p.Target }

--- a/query/testdata/10-edge-cases/self_referencing_parent/graph.gsl
+++ b/query/testdata/10-edge-cases/self_referencing_parent/graph.gsl
@@ -1,0 +1,6 @@
+node a
+node b
+node c
+node d
+E1:a->b
+E:b->c[parent=E]

--- a/query/testdata/10-edge-cases/self_referencing_parent/query.gql
+++ b/query/testdata/10-edge-cases/self_referencing_parent/query.gql
@@ -1,0 +1,1 @@
+subgraph edge.depth == 0

--- a/query/testdata/10-edge-cases/self_referencing_parent/result.gsl
+++ b/query/testdata/10-edge-cases/self_referencing_parent/result.gsl
@@ -1,0 +1,4 @@
+node a
+node b
+
+E1: a->b

--- a/query/testdata/README.md
+++ b/query/testdata/README.md
@@ -254,12 +254,14 @@ Minimal and unusual graph structures.
 | `01_self_loop_only` | Node with only self-loop, no other edges |
 | `02_disconnected_components` | Multiple disconnected subgraphs |
 | `03_duplicate_edges_preserved` | Multiple edges between same nodes |
+| `04_self_referencing_parent` | Edge with Label == Parent (self-reference in parent chain) |
 
 **Key Semantic Notes:**
 - Empty graph is valid result
 - Self-loop counts as incident edge
 - Duplicate edges preserved except during collapse
 - Disconnected components behave independently
+- Self-referencing parent edges are depth 1 (cycle detected, not depth 0)
 
 ---
 

--- a/serialize.go
+++ b/serialize.go
@@ -96,7 +96,9 @@ func serializeEdges(edges []*Edge) string {
 	labelIndex := make(map[string]*Edge)
 	for _, e := range edges {
 		if e.Label != "" {
-			labelIndex[e.Label] = e
+			if _, exists := labelIndex[e.Label]; !exists {
+				labelIndex[e.Label] = e
+			}
 		}
 	}
 
@@ -145,16 +147,16 @@ func serializeEdges(edges []*Edge) string {
 }
 
 // isEdgeCyclic walks the edge parent chain to detect cycles.
+// Uses edge pointer tracking to avoid false positives when two
+// different edges share the same label in the parent chain.
 func isEdgeCyclic(e *Edge, labelIndex map[string]*Edge) bool {
-	visited := make(map[string]bool)
+	visited := make(map[*Edge]bool)
 	current := e
 	for current != nil && current.Parent != "" {
-		if current.Label != "" {
-			if visited[current.Label] {
-				return true
-			}
-			visited[current.Label] = true
+		if visited[current] {
+			return true
 		}
+		visited[current] = true
 		parent, ok := labelIndex[current.Parent]
 		if !ok {
 			return false

--- a/serialize.go
+++ b/serialize.go
@@ -115,10 +115,29 @@ func serializeEdges(edges []*Edge) string {
 		}
 	}
 
+	// Group labeled root edges by label for grouped-edge serialization.
+	// Unlabeled root edges are serialized individually via serializeEdgeNested.
+	labelGroups := make(map[string][]*Edge)
+	for _, e := range edges {
+		if !childSet[e] && e.Label != "" {
+			labelGroups[e.Label] = append(labelGroups[e.Label], e)
+		}
+	}
+
 	var lines []string
 	visiting := make(map[string]bool)
+	seenLabels := make(map[string]bool)
+
 	for _, e := range edges {
-		if !childSet[e] {
+		if childSet[e] {
+			continue
+		}
+		if e.Label != "" {
+			if !seenLabels[e.Label] {
+				seenLabels[e.Label] = true
+				lines = append(lines, serializeLabeledEdgeGroup(labelGroups[e.Label], childMap, visiting))
+			}
+		} else {
 			lines = append(lines, serializeEdgeNested(e, childMap, visiting))
 		}
 	}
@@ -282,6 +301,95 @@ func serializeEdgeNested(e *Edge, childMap map[string][]*Edge, visiting map[stri
 		}
 		b.WriteString("}")
 		visiting[e.Label] = false
+	}
+
+	return b.String()
+}
+
+// serializeLabeledEdgeGroup serializes a group of edges sharing the same label
+// as a single grouped-edge declaration. It detects whether the edges all share
+// To (left-grouped: label: from1,from2,...->to) or all share From (right-grouped:
+// label: from->to1,to2,...). This ensures the output can be re-parsed without
+// triggering the duplicate edge label error.
+func serializeLabeledEdgeGroup(edges []*Edge, childMap map[string][]*Edge, visiting map[string]bool) string {
+	if len(edges) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	label := edges[0].Label
+
+	// Detect grouping pattern: all share To (left-grouped) or all share From (right-grouped)
+	allShareTo := true
+	for _, e := range edges[1:] {
+		if e.To != edges[0].To {
+			allShareTo = false
+			break
+		}
+	}
+
+	allShareFrom := true
+	for _, e := range edges[1:] {
+		if e.From != edges[0].From {
+			allShareFrom = false
+			break
+		}
+	}
+
+	b.WriteString(label)
+	b.WriteString(": ")
+
+	if allShareTo {
+		// Left-grouped: label: from1,from2,...->to
+		for i, e := range edges {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(e.From)
+		}
+		b.WriteString("->")
+		b.WriteString(edges[0].To)
+	} else if allShareFrom {
+		// Right-grouped: label: from->to1,to2,...
+		b.WriteString(edges[0].From)
+		b.WriteString("->")
+		for i, e := range edges {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(e.To)
+		}
+	} else {
+		// Fallback: shouldn't happen for parser-produced graphs
+		// (valid GSL produces edges that share From or To within a label)
+		// Serialize individually; re-parse may fail for API-constructed graphs.
+		var lines []string
+		for _, e := range edges {
+			lines = append(lines, serializeEdgeNested(e, childMap, visiting))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	// Attributes (all edges from the same declaration share attributes)
+	if len(edges[0].Attributes) > 0 {
+		b.WriteString(" ")
+		b.WriteString(serializeAttrs(edges[0].Attributes))
+	}
+
+	// Set memberships
+	b.WriteString(serializeSetMemberships(edges[0].Sets))
+
+	// Children (scoped block) — looked up by label
+	if children, ok := childMap[label]; ok && len(children) > 0 && !visiting[label] {
+		visiting[label] = true
+		b.WriteString(" {\n")
+		for _, child := range children {
+			childStr := serializeEdgeNested(child, childMap, visiting)
+			b.WriteString(indentBlock(childStr, "    "))
+			b.WriteString("\n")
+		}
+		b.WriteString("}")
+		visiting[label] = false
 	}
 
 	return b.String()

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -499,3 +499,85 @@ func TestSerializeNumberFormatting(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
 }
+
+func TestSerializeGroupedEdgeLeft(t *testing.T) {
+	// Multiple edges with same label and same To → left-grouped form
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"B": {ID: "B", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{From: "A", To: "Z", Label: "X", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			{From: "B", To: "Z", Label: "X", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+	)
+	got := Serialize(g)
+	// Edges share To=Z, so should be left-grouped: X: A,B->Z
+	expected := "node A\nnode B\n\nX: A,B->Z"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSerializeGroupedEdgeRight(t *testing.T) {
+	// Multiple edges with same label and same From → right-grouped form
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"B": {ID: "B", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"C": {ID: "C", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{From: "A", To: "B", Label: "X", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			{From: "A", To: "C", Label: "X", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+	)
+	got := Serialize(g)
+	// Edges share From=A, so should be right-grouped: X: A->B,C
+	expected := "node A\nnode B\nnode C\n\nX: A->B,C"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSerializeGroupedEdgeDuplicatePairs(t *testing.T) {
+	// Duplicate identical edges with same label group to one declaration
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{From: "A", To: "A", Label: "X", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			{From: "A", To: "A", Label: "X", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+	)
+	got := Serialize(g)
+	// Both edges identical (A→A, label X); both conditions true, left-grouped chosen
+	expected := "node A\n\nX: A,A->A"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSerializeGroupedEdgeSingle(t *testing.T) {
+	// Single labeled edge should serialize normally (no grouping needed)
+	g := testGraph(
+		map[string]*Node{
+			"A": {ID: "A", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+			"B": {ID: "B", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+		map[string]*Set{},
+		[]*Edge{
+			{From: "A", To: "B", Label: "E1", Attributes: map[string]interface{}{}, Sets: map[string]struct{}{}},
+		},
+	)
+	got := Serialize(g)
+	expected := "node A\nnode B\n\nE1: A->B"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
Fixes multiple crashes discovered by fuzz testing across the GSL pipeline — serialization, query execution, and parsing.

**Serialization round-trip**: Inputs like `A:A->A,A` (labeled grouped edges) and `A:A->A{A:B->B}` (scoped edges with same label on parent and child) produced canonical forms that failed to re-parse. Fixed by reconstructing grouped-edge declarations in the serializer and using first-write-wins for label resolution.

**Query depth recursion**: An edge with `Label == Parent` (e.g. `E:b->c[parent=E]`) caused infinite recursion in the depth predicate. Fixed with cycle tracking in `walkDepth`.

**Global label uniqueness**: Edge labels are now enforced as globally unique across all scopes (previously only checked the current block), since both the serializer and builder use flat label indices. Duplicate labels in nested scopes like `X: A -> B { X: C -> D }` are now correctly rejected.